### PR TITLE
Changed from form data to JSON when posting since NetBox expects JSON

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -63,7 +63,7 @@ class HttpClient implements HttpClientInterface
             'POST',
             config('netbox.sites.default.url').$path,
             [
-                'form_params' => $body
+                'json' => $body
             ]
         );
         return json_decode((string)$response->getBody(), true);
@@ -80,7 +80,7 @@ class HttpClient implements HttpClientInterface
             'PUT',
             config('netbox.sites.default.url').$path,
             [
-                'form_params' => $body
+                'json' => $body
             ]
         );
         return json_decode((string)$response->getBody(), true);
@@ -97,7 +97,7 @@ class HttpClient implements HttpClientInterface
             'DELETE',
             config('netbox.sites.default.url').$path,
             [
-                'form_params' => $body
+                'json' => $body
             ]
         );
         return json_decode((string)$response->getBody(), true);


### PR DESCRIPTION
NetBox expects JSON data in API requests to work properly. Some fields seems to work even when sending them as a normal form, but if you create a IP with a VRF reference or a VLAN with a reference to a VLAN group it results in a record being created but without the references. 

Changing from form_params to json in GET/PUT/DELETE-requests solves this. 